### PR TITLE
Deleted some old code, now hidden box with hooks

### DIFF
--- a/includes/admin/components/bouncer/wsl.components.bouncer.setup.php
+++ b/includes/admin/components/bouncer/wsl.components.bouncer.setup.php
@@ -330,14 +330,6 @@ function wsl_component_bouncer_setup_membership_level()
 
 // --------------------------------------------------------------------	
 
-// XTEC ************ AFEGIT - Hide "Filters by profile urls"
-// 2014.11.14 @aginard
-    global $isAgora;
-    if ($isAgora && !is_xtecadmin()) {
-        echo '<!--';
-    }
-//************ FI
-
 function wsl_component_bouncer_setup_filters_domains()
 {
 ?>
@@ -381,14 +373,6 @@ function wsl_component_bouncer_setup_filters_domains()
 <?php
 }
 
-// --------------------------------------------------------------------	
-
-// XTEC ************ AFEGIT -  Hide "Filters by profile urls"
-// 2014.11.14 @aginard
-    if ($isAgora && !is_xtecadmin()) {
-        echo '-->';
-    }
-//************ FI
 
 function wsl_component_bouncer_setup_filters_mails()
 {

--- a/includes/admin/components/networks/index.php
+++ b/includes/admin/components/networks/index.php
@@ -46,11 +46,10 @@ function wsl_component_networks()
 
                     // XTEC ************ AFEGIT - Remove side boxes
                     // 2014.11.14 @aginard
-                    global $isAgora, $isBlocs;
-                    if (($isAgora && !is_xtecadmin()) && !$isBlocs) {
+                    if (is_xtec_super_admin()) {
                     //************ FI
 
-						wsl_component_networks_sidebar();
+                                wsl_component_networks_sidebar();
 
                     // XTEC ************ AFEGIT - Remove side boxes
                     // 2014.11.14 @aginard

--- a/includes/admin/wsl.admin.ui.php
+++ b/includes/admin/wsl.admin.ui.php
@@ -41,7 +41,7 @@ function wsl_admin_main()
 	GLOBAL $WORDPRESS_SOCIAL_LOGIN_COMPONENTS;
 	GLOBAL $WORDPRESS_SOCIAL_LOGIN_PROVIDERS_CONFIG;
 	GLOBAL $WORDPRESS_SOCIAL_LOGIN_VERSION;
-
+       
 	if( isset( $_REQUEST["enable"] ) && isset( $WORDPRESS_SOCIAL_LOGIN_COMPONENTS[ $_REQUEST["enable"] ] ) )
 	{
 		$component = $_REQUEST["enable"];
@@ -64,20 +64,7 @@ function wsl_admin_main()
 		wsl_register_components();
 	}
 
-// XTEC ************ MODIFICAT - Hide tabs "Widget" and "Components"
-// 2014.11.14 @aginard
-    global $isAgora;
-
-    if ($isAgora) {
-        $wslp        = "users";
-    } else {
-    	$wslp        = "networks";
-    }
-//************ ORIGINAL
-/*
 	$wslp            = "networks";
-*/
-//************ FI
 
 	$wsldwp          = 0;
 	$assets_base_url = WORDPRESS_SOCIAL_LOGIN_PLUGIN_URL . '/assets/img/16x16/';
@@ -379,15 +366,6 @@ function wsl_admin_welcome_panel()
 	//> wsl-w-panel is shamelessly borrowed and modified from wordpress welcome-panel
 -->
 
-<!-- XTEC ************ AFEGIT - Remove Welcome banner -->
-<!-- 2014.11.14 @aginard -->
-<?php
-    global $isAgora, $isBlocs;
-    if (($isAgora && !is_xtecadmin()) || $isBlocs) {
-        echo '<!--';
-    }
-//************ FI (The following close PHP tag belongs to the patch) ?>
-
 <div id="wsl-w-panel">
 	<a href="options-general.php?page=wordpress-social-login&wslp=<?php echo $wslp ?>&wsldwp=1" id="wsl-w-panel-dismiss" <?php if( is_rtl() ) echo 'style="left: 10px;right: auto;"'; ?>><?php _wsl_e("Dismiss", 'wordpress-social-login') ?></a>
 
@@ -440,12 +418,6 @@ function wsl_admin_welcome_panel()
 </div>
 <?php
 
-// XTEC ************ AFEGIT - Remove Welcome banner
-// 2014.11.14 @aginard
-    if (($isAgora && !is_xtecadmin()) || $isBlocs) {
-        echo '-->';
-    }
-//************ FI
 
 }
 


### PR DESCRIPTION
Ara part dels elements (tabs) s'amagen amb hooks, no cal comentar blocs de codi al plugin (veure https://github.com/projectestac/agora_nodes/pull/252 )

Test: Després d'aplicar també el pull 252, un usuari no xtecadmin no ha de veure la pestanya "Ginys WSL" i les pestanyes de la dreta (icones) de "Components, Tools i Help"
